### PR TITLE
indexを明示的にする

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -26,6 +26,7 @@ const gtagId = import.meta.env.PUBLIC_GTAG_ID;
 <title>{title}</title>
 <meta name="title" content={title} />
 <meta name="description" content={description} />
+<meta name="robots" content="index,follow">
 
 <meta property="og:type" content="website" />
 <meta property="og:url" content={Astro.url} />


### PR DESCRIPTION
meta robotsテキストがなかったので、
googleにindexを明示的にする

一応siteでは出てくるので、indexされてないわけではないと思うが念の為
<img width="1386" alt="スクリーンショット 2024-07-22 12 40 57" src="https://github.com/user-attachments/assets/07c90495-c96d-4f75-aac5-39e849c63013">

## 備考
https://www.ispr.net/tools/power-rank-check/result

シンプルにドメインランクが弱いので、それが原因だと思われる
(なおかつ、PodcastやらXやらyoutubeの方がドメインランクが高く、そちらが公式だと思われているので、そちらのサイトたちに負けて、表示が押し下げられている可能性が高い)
![www ispr net_tools_power-rank-check_result (2)](https://github.com/user-attachments/assets/3f54bf27-6356-497d-88e3-f9cb08194bc1)

